### PR TITLE
Adds support for text

### DIFF
--- a/src/image.js
+++ b/src/image.js
@@ -6,7 +6,7 @@ const Color = require('color')
 const svg = require('./svg')
 const helper = require('./helper')
 
-function generateGradient(username, size) {
+function generateGradient(username, text, size) {
   const hash = crypto.createHash('md5').update(username).digest('hex')
 
   let firstColor = helper.hashStringToColor(hash)
@@ -26,6 +26,9 @@ function generateGradient(username, size) {
   let avatar = svg.replace('$FIRST', firstColor.hex())
   avatar = avatar.replace('$SECOND', helper.getMatchingColor(firstColor).hex())
 
+  avatar = avatar.replace(/(\$TEXT)/g, text)
+  avatar = avatar.replace(/(\$FONTSIZE)/g, (120 * 0.9) / text.length)
+
   avatar = avatar.replace(/(\$SIZE)/g, size)
 
   return avatar
@@ -39,13 +42,13 @@ function parseSize(size) {
   return 120
 }
 
-exports.generateSVG = function(username, size) {
+exports.generateSVG = function(username, text, size) {
   size = parseSize(size)
-  return generateGradient(username, size)
+  return generateGradient(username, text, size)
 }
 
 exports.generatePNG = function(username, size) {
   size = parseSize(size)
-  const svg = generateGradient(username, size)
+  const svg = generateGradient(username, '', size)
   return sharp(new Buffer(svg)).png()
 }

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ module.exports = (req, res) => {
   }
   if (query.type === 'svg' || svgExt.test(pathname)) {
     res.setHeader('Content-Type', 'image/svg+xml')
-    return image.generateSVG(pathname.replace(svgExt, ''), query.size)
+    return image.generateSVG(pathname.replace(svgExt, ''), query.text || '', query.size)
   }
   res.setHeader('Content-Type', 'image/png')
   return image.generatePNG(pathname.replace(pngExt, ''), query.size)

--- a/src/svg.js
+++ b/src/svg.js
@@ -1,6 +1,6 @@
 module.exports = `<?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="$SIZE" height="$SIZE" viewBox="120 120 120 120" version="1.1" xmlns="http://www.w3.org/2000/svg">
+<svg width="$SIZE" height="$SIZE" viewBox="0 0 120 120" version="1.1" xmlns="http://www.w3.org/2000/svg">
   <g>
     <defs>
       <linearGradient id="avatar" x1="0" y1="0" x2="1" y2="1">
@@ -8,8 +8,8 @@ module.exports = `<?xml version="1.0" standalone="no"?>
         <stop offset="100%" stop-color="$SECOND"/>
       </linearGradient>
     </defs>
-
-    <rect fill="url(#avatar)" x="120" y="120" width="120" height="120"/>
+    <rect fill="url(#avatar)" x="0" y="0" width="120" height="120"/>
+    <text x="50%" y="52.5%" alignment-baseline="middle" text-anchor="middle" fill="#fff" font-family="sans-serif" font-size="$FONTSIZE">$TEXT</text>
   </g>
 </svg>
 `


### PR DESCRIPTION
This PR adds support for adding text overlay to an avatar. (e.g. for initials)
Text resizing is best-effort, we all know text has weird quirks in SVG. ;) 

`http://localhost:3000/michiel?type=svg&text=MDM&size=600`
<img width="599" alt="screen shot 2017-05-23 at 17 31 36" src="https://cloud.githubusercontent.com/assets/793406/26362331/e0fdf46c-3fdd-11e7-8cfc-3d40af0d882b.png">

`http://localhost:3000/michiel?type=svg&text=Michiel%20De%20Mey&size=600`
<img width="598" alt="screen shot 2017-05-23 at 17 33 11" src="https://cloud.githubusercontent.com/assets/793406/26362401/18e8ac1e-3fde-11e7-987b-7f9bf80d2fca.png">

Currently only works for SVG output due to rendering discrepancy in PNG.
(Does not seem to support `alignment-baseline`.)