### PR TITLE
Make svg text resizeable as per the height of the image requested

### DIFF
--- a/src/image.js
+++ b/src/image.js
@@ -26,11 +26,12 @@ function generateGradient(username, text, width, height) {
   let avatar = svg.replace('$FIRST', firstColor.hex())
   avatar = avatar.replace('$SECOND', helper.getMatchingColor(firstColor).hex())
 
-  avatar = avatar.replace(/(\$TEXT)/g, text)
-  avatar = avatar.replace(/(\$FONTSIZE)/g, (120 * 0.9) / text.length)
-
   avatar = avatar.replace(/(\$WIDTH)/g, width)
   avatar = avatar.replace(/(\$HEIGHT)/g, height)
+
+  avatar = avatar.replace(/(\$TEXT)/g, text)
+  avatar = avatar.replace(/(\$FONTSIZE)/g, (height * 0.9) / text.length)
+
 
   return avatar
 }


### PR DESCRIPTION
I noticed that the texts are not resized as per the size parameter. This is a PR fixing the same, the text size is resized according to the height requested. 
Tested the  following urls:

```
http://localhost:3000/sdsd.svg?text=s
http://localhost:3000/sdsd.svg?text=ss
http://localhost:3000/sdsd.svg?text=ss&size=30
http://localhost:3000/sdsd.svg?text=ss&size=30x50
```