### PR TITLE
Changed dominant-baseline for SVG to central

### DIFF
--- a/src/svg.js
+++ b/src/svg.js
@@ -9,7 +9,7 @@ module.exports = `<?xml version="1.0" standalone="no"?>
       </linearGradient>
     </defs>
     <rect fill="url(#avatar)" x="0" y="0" width="$WIDTH" height="$HEIGHT"/>
-    <text x="50%" y="50%" alignment-baseline="central" dominant-baseline="middle" text-anchor="middle" fill="#fff" font-family="sans-serif" font-size="$FONTSIZE">$TEXT</text>
+    <text x="50%" y="50%" alignment-baseline="central" dominant-baseline="central" text-anchor="middle" fill="#fff" font-family="sans-serif" font-size="$FONTSIZE">$TEXT</text>
   </g>
 </svg>
 `


### PR DESCRIPTION
When avatars are cropped (i.e. with a border radius), the text would not appear to be centered in Firefox. Settings the dominant-baseline to central solves this.
Before: 
![avatar_before](https://user-images.githubusercontent.com/963660/75961686-be718b00-5ec2-11ea-8ece-0de4bb8ec20a.png)
After:
![avatar_after](https://user-images.githubusercontent.com/963660/75961699-c4676c00-5ec2-11ea-9e0e-98bf2e9ce2d4.png)

