### PR TITLE
fix: file name parsing

### DIFF
--- a/pages/api/avatar/[name].tsx
+++ b/pages/api/avatar/[name].tsx
@@ -11,7 +11,7 @@ export default async function (req: NextRequest) {
   const name = url.searchParams.get("name");
   const text = url.searchParams.get("text");
   const size = Number(url.searchParams.get("size") || "120");
-  const [username, type] = name?.split(".") || [];
+  const { 0: username, length, [length - 1]: type }: { length: number, [key: number]: string } = name?.split(".") || [];
   const fileType = type?.includes("svg") ? "svg" : "png";
 
   const gradient = generateGradient(username || Math.random() + "");


### PR DESCRIPTION
Hello! I have observed an unusual behavior with [avatar.vercel.sh](https://avatar.vercel.sh/). The service only provides users with PNG files, even when .svg is specified at the end of the filename. While attempting to find a potential bug, I discovered another minor issue during my code review: if someone requests https://avatar.vercel.sh/username.svg.png, the service responds with an SVG file, which is not quite accurate. I have corrected this issue.

Best regards,
Vaguue.