### PR TITLE
Fix gradient generation to reduce hue collisions for longer usernames

### DIFF
--- a/utils/gradient.ts
+++ b/utils/gradient.ts
@@ -18,7 +18,8 @@ export function generateGradient(username: string) {
   const hue2 = Math.abs(hash2) % 360;
 
   const c1 = color({ h: hue, s: 0.95, l: 0.5 });
-  const c2 = color({ h: hue2, s: 0.95, l: 0.5 });
+  const triadColors = c1.triad();
+  const c2 = triadColors[1].spin(hue2);
 
   return {
     fromColor: c1.toHexString(),

--- a/utils/gradient.ts
+++ b/utils/gradient.ts
@@ -9,11 +9,19 @@ export function djb2(str: string) {
 }
 
 export function generateGradient(username: string) {
-  const c1 = color({ h: djb2(username) % 360, s: 0.95, l: 0.5 });
-  const second = c1.triad()[1].toHexString();
+  const hue = djb2(username) % 360;
+
+  let hash2 = 7;
+  for (let i = 0; i < username.length; i++) {
+    hash2 = hash2 * 31 + username.charCodeAt(i);
+  }
+  const hue2 = Math.abs(hash2) % 360;
+
+  const c1 = color({ h: hue, s: 0.95, l: 0.5 });
+  const c2 = color({ h: hue2, s: 0.95, l: 0.5 });
 
   return {
     fromColor: c1.toHexString(),
-    toColor: second,
+    toColor: c2.toHexString(),
   };
 }


### PR DESCRIPTION
Hi @tobiaslins,

**What did I change?**  
- Improved the `generateGradient` function by introducing a secondary hash function to reduce hue collisions for longer usernames.
- Kept lightness and saturation values constant, while ensuring more unique gradients by varying the hue.

**Why did I change it?**  
- Longer usernames were producing similar or identical gradients due to collisions in the `djb2` hash function. This update enhances the uniqueness of gradients, ensuring better differentiation for longer strings without changing lightness or saturation.

### Linked Issues

Close: #52 