### PR TITLE
fix: remove duplicate modulo operator

### DIFF
--- a/utils/gradient.ts
+++ b/utils/gradient.ts
@@ -6,7 +6,7 @@ async function hash(str: string): Promise<number> {
   for (const n of new Uint8Array(buffer)) {
     sum += n;
   }
-  return sum % 360;
+  return sum;
 }
 
 async function hue(str: string): Promise<number> {


### PR DESCRIPTION
The `% 360` was happening twice so I removed one.

This won't change the result, just doing less work.