### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ You will receive a `png` image with a size of 120\*120px
 
 ![Avatar for rauchg](https://avatar.vercel.sh/rauchg)
 
+### Adjust Roundness
+
+```
+https://avatar.vercel.sh/rauchg?rounded=60
+```
+
+![Avatar for rauchg](https://avatar.vercel.sh/rauchg?rounded=60)
+
+<!-- Delete This -->
+![Avatar for rauchg](https://avatar-jig9j3gwu.vercel.sh/rauchg?rounded=60)
+
 ### Custom Size
 
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ https://avatar.vercel.sh/rauchg?rounded=60
 
 ![Avatar for rauchg](https://avatar.vercel.sh/rauchg?rounded=60)
 
-
 ### Custom Size
 
 ```

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ https://avatar.vercel.sh/rauchg?rounded=60
 
 ![Avatar for rauchg](https://avatar.vercel.sh/rauchg?rounded=60)
 
-<!-- Delete This -->
-![Avatar for rauchg](https://avatar-jig9j3gwu.vercel.sh/rauchg?rounded=60)
 
 ### Custom Size
 

--- a/pages/api/avatar/[name].tsx
+++ b/pages/api/avatar/[name].tsx
@@ -11,9 +11,10 @@ export default async function (req: NextRequest) {
   const name = url.searchParams.get("name");
   const text = url.searchParams.get("text");
   const size = Number(url.searchParams.get("size") || "120");
+  const rounded = Number(url.searchParams.get("rounded") || "0");
   const [username, type] = name?.split(".") || [];
   const fileType = type?.includes("svg") ? "svg" : "png";
-
+  
   const gradient = await generateGradient(username || Math.random() + "");
 
   const avatar = (
@@ -31,7 +32,7 @@ export default async function (req: NextRequest) {
             <stop offset="100%" stopColor={gradient.toColor} />
           </linearGradient>
         </defs>
-        <rect fill="url(#gradient)" x="0" y="0" width={size} height={size} />
+        <rect fill="url(#gradient)" x="0" y="0" width={size} height={size} rx={rounded} ry={rounded} />
         {fileType === "svg" && text && (
           <text
             x="50%"


### PR DESCRIPTION
I don't know why, but the roundness adjustment feature(#56) is applied in [Preview](https://avatar-jig9j3gwu.vercel.sh/rauchg?rounded=60), but not yet in the [Production](https://avatar.vercel.sh/rauchg?rounded=60) page.

If it is applied, I would like to add the roundness adjustment feature to the README for users.

The part marked as `<!-- Delete This -->` is the part that will be deleted when roundness adjustment feature is applied to the Production page.